### PR TITLE
Исправление ориентации при конвертации в webp

### DIFF
--- a/utf8/dev2fun.imagecompress/lib/WebpConvertPhp.php
+++ b/utf8/dev2fun.imagecompress/lib/WebpConvertPhp.php
@@ -152,6 +152,20 @@ class WebpConvertPhp
                 break;
             case 'image/jpeg':
                 $img = \imageCreateFromJpeg($src);
+                $exif = exif_read_data($src);
+                if (!empty($exif['Orientation'])) {
+                    switch ($exif['Orientation']) {
+                        case 3: // Rotate 180 degrees
+                            $img = imagerotate($img, 180, 0);
+                            break;
+                        case 6: // Rotate 90 degrees CW
+                            $img = imagerotate($img, -90, 0);
+                            break;
+                        case 8: // Rotate 90 degrees CCW
+                            $img = imagerotate($img, 90, 0);
+                            break;
+                    }
+                }
                 break;
         }
         if (empty($img)) {

--- a/win1251/dev2fun.imagecompress/lib/WebpConvertPhp.php
+++ b/win1251/dev2fun.imagecompress/lib/WebpConvertPhp.php
@@ -152,6 +152,20 @@ class WebpConvertPhp
                 break;
             case 'image/jpeg':
                 $img = \imageCreateFromJpeg($src);
+                $exif = exif_read_data($src);
+                if (!empty($exif['Orientation'])) {
+                    switch ($exif['Orientation']) {
+                        case 3: // Rotate 180 degrees
+                            $img = imagerotate($img, 180, 0);
+                            break;
+                        case 6: // Rotate 90 degrees CW
+                            $img = imagerotate($img, -90, 0);
+                            break;
+                        case 8: // Rotate 90 degrees CCW
+                            $img = imagerotate($img, 90, 0);
+                            break;
+                    }
+                }
                 break;
         }
         if (empty($img)) {


### PR DESCRIPTION
При обработке изображений с использованием imagecreatefromjpeg и последующем сохранении через imagewebp, некоторые изображения могли некорректно отображаться (переворачиваться или вращаться). Это происходило из-за того, что GD-библиотека по умолчанию не учитывает поле Orientation из EXIF-данных JPEG-файлов. Это поле определяет ориентацию изображения (например, поворот на 90° или 180°), которую устанавливает камера или другое устройство.