### PR TITLE
Фикс ошибки конвертации при отсутствии хеша картинки

### DIFF
--- a/utf8/dev2fun.imagecompress/lib/LazyConvert.php
+++ b/utf8/dev2fun.imagecompress/lib/LazyConvert.php
@@ -68,6 +68,7 @@ class LazyConvert
                     ? Convert::TYPE_AVIF
                     : Convert::TYPE_WEBP,
                 '!=IMAGE_IGNORE' => 'Y',
+                '!=IMAGE_HASH' => false,
 //                [
 //                    'Dev2fun\ImageCompress\ImageCompressImagesToConvertedTable:IMAGE.IMAGE_TYPE',
 //                    '!=',

--- a/win1251/dev2fun.imagecompress/lib/LazyConvert.php
+++ b/win1251/dev2fun.imagecompress/lib/LazyConvert.php
@@ -68,6 +68,7 @@ class LazyConvert
                     ? Convert::TYPE_AVIF
                     : Convert::TYPE_WEBP,
                 '!=IMAGE_IGNORE' => 'Y',
+                '!=IMAGE_HASH' => false,
 //                [
 //                    'Dev2fun\ImageCompress\ImageCompressImagesToConvertedTable:IMAGE.IMAGE_TYPE',
 //                    '!=',


### PR DESCRIPTION
Привет!

У меня откуда-то в таблице `b_d2f_imagecompress_images` много файлов в абсолютными путями (с протоколом и доменом) и без хеша

![image](https://github.com/user-attachments/assets/67398963-46a6-415a-930b-ebd0d6bef2c9)

Такие файлы генерят много ошибок

![image](https://github.com/user-attachments/assets/443a40c4-f7f2-4c9f-af1e-6c18fe8c5472)

И в итоге полностью забивают очередь внутри агента `Dev2fun\ImageCompress\LazyConvert::agentRun();`, останавливая конвертацию

Этот PR исправляет это
