### PR TITLE
Фикс ошибки отсутствия библиотек

### DIFF
--- a/utf8/dev2fun.imagecompress/lib/Gif.php
+++ b/utf8/dev2fun.imagecompress/lib/Gif.php
@@ -62,7 +62,7 @@ class Gif
         }
         if (self::$isOptim === null || $path !== $this->path) {
             if (!\Dev2funImageCompress::checkAvailable("{$path}/gifsicle")) {
-                throw new \Exception("gifsicle no readable or executable");
+                return false;
             }
             exec($path . '/gifsicle --version', $s);
             self::$isOptim = (bool)$s;

--- a/utf8/dev2fun.imagecompress/lib/Jpegoptim.php
+++ b/utf8/dev2fun.imagecompress/lib/Jpegoptim.php
@@ -74,7 +74,7 @@ class Jpegoptim
         }
         if (self::$isOptim === null || $path !== $this->jpegOptimPath) {
             if (!\Dev2funImageCompress::checkAvailable("{$path}/jpegoptim")) {
-                throw new \Exception("jpegoptim no readable or executable");
+                return false;
             }
             exec($path . '/jpegoptim --version', $s);
             self::$isOptim = (bool)$s;

--- a/utf8/dev2fun.imagecompress/lib/Optipng.php
+++ b/utf8/dev2fun.imagecompress/lib/Optipng.php
@@ -74,7 +74,7 @@ class Optipng
         }
         if (self::$isOptim === null || $path !== $this->pngOptimPath) {
             if (!\Dev2funImageCompress::checkAvailable("{$path}/optipng")) {
-                throw new \Exception("{$path}/optipng no readable or executable");
+                return false;
             }
             exec($path . '/optipng -v', $s);
             self::$isOptim = (bool)$s;

--- a/utf8/dev2fun.imagecompress/lib/Ps2Pdf.php
+++ b/utf8/dev2fun.imagecompress/lib/Ps2Pdf.php
@@ -77,7 +77,7 @@ class Ps2Pdf
             $path = $this->path;
         }
         if (!\Dev2funImageCompress::checkAvailable("{$path}/gs")) {
-            throw new \Exception("{$path}/gs no readable or executable");
+            return false;
         }
         if (self::$isOptim === null || $path !== $this->path) {
             \exec($path . '/gs -v', $s);

--- a/utf8/dev2fun.imagecompress/lib/Svg.php
+++ b/utf8/dev2fun.imagecompress/lib/Svg.php
@@ -75,7 +75,7 @@ class Svg
             $pathNodejs = $this->pathNodejs;
         }
         if (!\Dev2funImageCompress::checkAvailable("{$path}/{$this->binaryName}")) {
-            throw new \Exception("{$path}/{$this->binaryName} no readable or executable");
+            return false;
         }
         if (self::$isOptim === null || $path !== $this->path || $pathNodejs !== $this->pathNodejs) {
             exec("{$pathNodejs}/node {$path}/{$this->binaryName} -v", $s);

--- a/utf8/dev2fun.imagecompress/lib/Webp.php
+++ b/utf8/dev2fun.imagecompress/lib/Webp.php
@@ -89,7 +89,7 @@ class Webp
         }
         if (self::$isOptim === null || $path !== $this->path) {
             if (!\Dev2funImageCompress::checkAvailable("{$path}/cwebp")) {
-                throw new \Exception("{$path}/cwebp no readable or executable");
+                return false;
             }
             exec($path . '/cwebp -version', $s);
             self::$isOptim = (bool)$s;

--- a/win1251/dev2fun.imagecompress/lib/Gif.php
+++ b/win1251/dev2fun.imagecompress/lib/Gif.php
@@ -62,7 +62,7 @@ class Gif
         }
         if (self::$isOptim === null || $path !== $this->path) {
             if (!\Dev2funImageCompress::checkAvailable("{$path}/gifsicle")) {
-                throw new \Exception("gifsicle no readable or executable");
+                return false;
             }
             exec($path . '/gifsicle --version', $s);
             self::$isOptim = (bool)$s;

--- a/win1251/dev2fun.imagecompress/lib/Jpegoptim.php
+++ b/win1251/dev2fun.imagecompress/lib/Jpegoptim.php
@@ -74,7 +74,7 @@ class Jpegoptim
         }
         if (self::$isOptim === null || $path !== $this->jpegOptimPath) {
             if (!\Dev2funImageCompress::checkAvailable("{$path}/jpegoptim")) {
-                throw new \Exception("jpegoptim no readable or executable");
+                return false;
             }
             exec($path . '/jpegoptim --version', $s);
             self::$isOptim = (bool)$s;

--- a/win1251/dev2fun.imagecompress/lib/Optipng.php
+++ b/win1251/dev2fun.imagecompress/lib/Optipng.php
@@ -74,7 +74,7 @@ class Optipng
         }
         if (self::$isOptim === null || $path !== $this->pngOptimPath) {
             if (!\Dev2funImageCompress::checkAvailable("{$path}/optipng")) {
-                throw new \Exception("{$path}/optipng no readable or executable");
+                return false;
             }
             exec($path . '/optipng -v', $s);
             self::$isOptim = (bool)$s;

--- a/win1251/dev2fun.imagecompress/lib/Ps2Pdf.php
+++ b/win1251/dev2fun.imagecompress/lib/Ps2Pdf.php
@@ -77,7 +77,7 @@ class Ps2Pdf
             $path = $this->path;
         }
         if (!\Dev2funImageCompress::checkAvailable("{$path}/gs")) {
-            throw new \Exception("{$path}/gs no readable or executable");
+            return false;
         }
         if (self::$isOptim === null || $path !== $this->path) {
             \exec($path . '/gs -v', $s);

--- a/win1251/dev2fun.imagecompress/lib/Svg.php
+++ b/win1251/dev2fun.imagecompress/lib/Svg.php
@@ -75,7 +75,7 @@ class Svg
             $pathNodejs = $this->pathNodejs;
         }
         if (!\Dev2funImageCompress::checkAvailable("{$path}/{$this->binaryName}")) {
-            throw new \Exception("{$path}/{$this->binaryName} no readable or executable");
+            return false;
         }
         if (self::$isOptim === null || $path !== $this->path || $pathNodejs !== $this->pathNodejs) {
             exec("{$pathNodejs}/node {$path}/{$this->binaryName} -v", $s);

--- a/win1251/dev2fun.imagecompress/lib/Webp.php
+++ b/win1251/dev2fun.imagecompress/lib/Webp.php
@@ -89,7 +89,7 @@ class Webp
         }
         if (self::$isOptim === null || $path !== $this->path) {
             if (!\Dev2funImageCompress::checkAvailable("{$path}/cwebp")) {
-                throw new \Exception("{$path}/cwebp no readable or executable");
+                return false;
             }
             exec($path . '/cwebp -version', $s);
             self::$isOptim = (bool)$s;


### PR DESCRIPTION
До версии [0.11.7](https://github.com/darkfriend/dev2fun.imagecompress/releases/tag/0.11.7) при проверки конфигурации сервера ошибка выглядела так:

![image](https://github.com/user-attachments/assets/9bbe747d-8f87-4b0d-9147-d4465e37e8d8)

а сейчас (при той же конфигурации) вот так:

![image](https://github.com/user-attachments/assets/b639b467-910a-43da-beeb-bbfa0d412cd7)

т.к. этот участок кода не ожидает Exception: https://github.com/darkfriend/dev2fun.imagecompress/blob/f00e13094b71a7f9901f3a2d28cdd99146570df6/utf8/dev2fun.imagecompress/options.php#L87-L91

Я его убрал, т.к. задача isser методов- вернуть boolean, не влияя на состояние системы и не провоцируя ошибки